### PR TITLE
Fix package group names in desktop.ks and desktopencrypt.ks

### DIFF
--- a/desktop.ks
+++ b/desktop.ks
@@ -12,7 +12,7 @@ firstboot --enable
 poweroff
 
 %packages
-@^workstation-product-environment
+@^workstation-product
 -selinux-policy-minimum
 %end
 

--- a/desktopencrypt.ks
+++ b/desktopencrypt.ks
@@ -12,6 +12,6 @@ firstboot --enable
 poweroff
 
 %packages
-@^workstation-product-environment
+@^workstation-product
 -selinux-policy-minimum
 %end


### PR DESCRIPTION
I can't find any version of Rocky Linux 8 that had `workstation-product-environment` as valid package groups in comps.xml, so not sure how this could have worked in the past.  

Removing `-environment` from the package group made these kickstarts work with RL 8.5 and 8.6 comps.xml package groups.