### PR TITLE
Increase size of disk_full.img

### DIFF
--- a/hdds.json
+++ b/hdds.json
@@ -2,19 +2,19 @@
     "guestfs" : [
         {
             "name" : "full",
-            "size" : "10G",
+            "size" : "25G",
             "labels" : ["mbr", "gpt"],
             "parts" : [
                 {
                     "filesystem" : "ext4",
                     "type" : "p",
                     "start" : "4096",
-                    "end" : "10485760"
+                    "end" : "26214400"
                 },
                 {
                     "filesystem" : "ext4",
                     "type" : "p",
-                    "start" : "10485761",
+                    "start" : "26214401",
                     "end" : "-4097"
                 }
             ],


### PR DESCRIPTION
This PR increases the size of `disk_full_*.img` to account for additional required space for package installations. Fixes [os-autoinst-distri-rocky:#80](https://github.com/rocky-linux/os-autoinst-distri-rocky/issues/80) when merged.