### PR TITLE
feat: improvements for createhdds

### DIFF
--- a/createhdds.py
+++ b/createhdds.py
@@ -197,8 +197,7 @@ class GuestfsImage(object):
 
 class VirtInstallImage(object):
     """Class representing an image created by virt-install. 'release'
-    is the release the image will be built for. 'variant' is the
-    variant whose install tree should be used. 'arch' is the arch.
+    is the release the image will be built for. 'arch' is the arch.
     'size' is the desired image size, in gigabytes. 'imgver' is
     the image 'version' - in practice it's simply a string that gets
     included in the image file name if specified. 'maxage' is the
@@ -207,7 +206,7 @@ class VirtInstallImage(object):
     rebuild it. 'bootopts' are used to pass boot options to the
     virtual image to provide better control of the VM.
     """
-    def __init__(self, name, release, arch, size, variant=None, imgver='', maxage=14, bootopts=None):
+    def __init__(self, name, release, arch, size, imgver='', maxage=14, bootopts=None):
         self.name = name
         self.size = size
         self.filename = "disk_rocky{0}_{1}".format(str(release), name)
@@ -215,16 +214,8 @@ class VirtInstallImage(object):
             self.filename = "{0}_{1}".format(self.filename, imgver)
         self.filename = "{0}_{1}.qcow2".format(self.filename, arch)
         self.release = release
-        self.variant = variant
         self.arch = arch
         self.maxage = maxage
-        if variant:
-            self.variant = variant
-        else:
-            if str(release).isdigit() and int(release) < 24:
-                self.variant = "Server"
-            else:
-                self.variant = "Everything"
         self.bootopts = bootopts
 
     @property
@@ -290,11 +281,6 @@ class VirtInstallImage(object):
             rockydir = 'rocky-secondary'
             memsize = '4096'
 
-        variant = self.variant
-        # From F31 onwards, Workstation tree is not installable and we
-        # build Workstation images out of Everything
-        # We will always use the dvd1 ISO and the closest behavior is the Everything variant
-        variant = 'Everything'
         try:
             # loctmp is the Distribution tree installation source. Point at the good location
             #loctmp = "https://download.rockylinux.org/stg/rocky/{0}/BaseOS/{1}/os"
@@ -470,8 +456,6 @@ def get_virtinstall_images(imggrp, nextrel=None, releases=None):
     name = imggrp['name']
     # this is the second place we set a default for maxage - bit ugly
     maxage = int(imggrp.get('maxage', 14))
-    # ditto variant
-    variant = imggrp.get('variant')
     if not releases:
         releases = imggrp['releases']
     size = imggrp.get('size', 0)
@@ -486,7 +470,7 @@ def get_virtinstall_images(imggrp, nextrel=None, releases=None):
                     continue
                 key = "{0}-{1}".format(rel, arch)
                 # using a dict here avoids dupes
-                imgs[key] = VirtInstallImage(name, rel, arch, variant=variant, size=size,
+                imgs[key] = VirtInstallImage(name, rel, arch, size=size,
                                              imgver=imgver, maxage=maxage, bootopts=bootopts)
     return list(imgs.values())
 

--- a/createhdds.py
+++ b/createhdds.py
@@ -286,14 +286,9 @@ class VirtInstallImage(object):
         arch = self.arch
         rockydir = 'rocky/linux'
         memsize = '3072'
-        if arch == 'i686':
-            arch = 'i386'
         if arch in ['ppc64','ppc64le']:
             rockydir = 'rocky-secondary'
             memsize = '4096'
-        if arch == 'i386':
-            # i686 is in rocky-secondary (until it died)
-            rockydir = 'rocky-secondary'
 
         variant = self.variant
         # From F31 onwards, Workstation tree is not installable and we

--- a/hdds.json
+++ b/hdds.json
@@ -145,8 +145,7 @@
                 "8": ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
-            "size" : "20",
-            "variant": "Workstation"
+            "size" : "20"
         },
         {
             "name" : "desktopencrypt",
@@ -154,8 +153,7 @@
                 "8" : ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
-            "size" : "20",
-            "variant": "Workstation"
+            "size" : "20"
         },
         {
             "name" : "server",
@@ -163,8 +161,7 @@
                 "8" : ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
-            "size" : "9",
-            "variant": "Server"
+            "size" : "9"
         },
         {
             "name" : "support",

--- a/hdds.json
+++ b/hdds.json
@@ -125,14 +125,16 @@
         {
             "name" : "minimal",
             "releases" : {
-                "8" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "15"
         },
         {
             "name" : "minimal-uefi",
             "releases" : {
-                "8" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "15",
             "bootopts": "uefi"
@@ -140,7 +142,8 @@
         {
             "name" : "desktop",
             "releases" : {
-                "8": ["x86_64", "aarch64"]
+                "8": ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "20",
             "variant": "Workstation"
@@ -148,7 +151,8 @@
         {
             "name" : "desktopencrypt",
             "releases" : {
-                "8" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "20",
             "variant": "Workstation"
@@ -156,7 +160,8 @@
         {
             "name" : "server",
             "releases" : {
-                "8" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "9",
             "variant": "Server"
@@ -164,7 +169,8 @@
         {
             "name" : "support",
             "releases" : {
-                "8" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "15"
         }

--- a/hdds.json
+++ b/hdds.json
@@ -125,14 +125,14 @@
         {
             "name" : "minimal",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"]
             },
             "size" : "15"
         },
         {
             "name" : "minimal-uefi",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"]
             },
             "size" : "15",
             "bootopts": "uefi"
@@ -140,7 +140,7 @@
         {
             "name" : "desktop",
             "releases" : {
-                "8.6": ["x86_64", "aarch64"]
+                "8": ["x86_64", "aarch64"]
             },
             "size" : "20",
             "variant": "Workstation"
@@ -148,7 +148,7 @@
         {
             "name" : "desktopencrypt",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"]
             },
             "size" : "20",
             "variant": "Workstation"
@@ -156,7 +156,7 @@
         {
             "name" : "server",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"]
             },
             "size" : "9",
             "variant": "Server"
@@ -164,7 +164,7 @@
         {
             "name" : "support",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"]
             },
             "size" : "15"
         }


### PR DESCRIPTION
# Description

This PR removes the use of `variant` from `createhdds.py` in the sense that they are used by Fedora to identify different types of composes and media (ie. Server, Workstation, etc...). Since Rocky doesn't have variants in that sense it makes sense to remove these and move towards our own nomenclature.

Also removed is built-in backwards support for i386 and i686 architecture specific images which Rocky will never have.

Finally, support is added to `createhdds.py` (via `hdds.json`) for building disk images for Rocky 9 using `virt-install`. _NOTE: This capability will need further development work to be complete._

# How Has This Been Tested?

```bash
[rocky@openqa-dev createhdds]$ cd /var/lib/openqa/factory/hdd/fixed
[rocky@openqa-dev fixed]$ ~/createhdds/createhdds.py check
Missing images: disk_full_mbr.img, disk_full_gpt.img, disk_freespace_mbr.img, disk_freespace_gpt.img, disk_ks.img, disk_updates_img.img, disk_shrink_ext4.img, disk_shrink_ntfs.img, disk_rocky8_minimal_x86_64.qcow2, disk_rocky8_minimal-uefi_x86_64.qcow2, disk_rocky8_desktop_x86_64.qcow2, disk_rocky8_desktopencrypt_x86_64.qcow2, disk_rocky8_server_x86_64.qcow2, disk_rocky8_support_x86_64.qcow2
Unknown images: disk_rocky8.6_desktop_x86_64.qcow2, disk_rocky8.6_support_x86_64.qcow2, disk_rocky8.6_minimal_x86_64.qcow2, disk_rocky8.6_server_x86_64.qcow2
```

```bash
[rocky@openqa-dev fixed]$ ~/createhdds/createhdds.py ks
INFO:createhdds:Creating image disk_ks.img...[1/1]
```

```bash

[rocky@openqa-dev fixed]$ ~/createhdds/createhdds.py -t minimal
INFO:createhdds:Creating image disk_rocky8_minimal_x86_64.qcow2...[1/2]
libvirt: Domain Config error : Requested operation is not valid: domain is not running
INFO:createhdds:Install starting...

Starting install...
Retrieving file vmlinuz...                                                                              |  10 MB  00:00:00
Retrieving file initrd.img...                                                                           |  79 MB  00:00:05
Allocating 'disk_rocky8_minimal_x86_64.qcow2.tmp'                            |  15 GB  00:00:00
Running text console command: virsh --connect qemu:///session console createhdds
Connected to domain 'createhdds'
Escape character is ^] (Ctrl + ])
rd PC (Q35 + ICH9, 2009), BIOS 1.14.0-4.fc34 04/01/2014
[    0.000000] Hypervisor detected: KVM
[    0.000000] kvm-clock: Using msrs 4b564d01 and 4b564d00
[    0.000000] kvm-clock: cpu 0, msr 1f001001, primary cpu clock
...
```

**NOTE: Support for building virt-install machines for Rocky 9 has not been developed or tested.**

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules