### PR TITLE
feat: add temporary support for Rocky Linux 9

### DIFF
--- a/createhdds.py
+++ b/createhdds.py
@@ -197,8 +197,7 @@ class GuestfsImage(object):
 
 class VirtInstallImage(object):
     """Class representing an image created by virt-install. 'release'
-    is the release the image will be built for. 'variant' is the
-    variant whose install tree should be used. 'arch' is the arch.
+    is the release the image will be built for. 'arch' is the arch.
     'size' is the desired image size, in gigabytes. 'imgver' is
     the image 'version' - in practice it's simply a string that gets
     included in the image file name if specified. 'maxage' is the
@@ -207,7 +206,7 @@ class VirtInstallImage(object):
     rebuild it. 'bootopts' are used to pass boot options to the
     virtual image to provide better control of the VM.
     """
-    def __init__(self, name, release, arch, size, variant=None, imgver='', maxage=14, bootopts=None):
+    def __init__(self, name, release, arch, size, imgver='', maxage=14, bootopts=None):
         self.name = name
         self.size = size
         self.filename = "disk_rocky{0}_{1}".format(str(release), name)
@@ -215,16 +214,8 @@ class VirtInstallImage(object):
             self.filename = "{0}_{1}".format(self.filename, imgver)
         self.filename = "{0}_{1}.qcow2".format(self.filename, arch)
         self.release = release
-        self.variant = variant
         self.arch = arch
         self.maxage = maxage
-        if variant:
-            self.variant = variant
-        else:
-            if str(release).isdigit() and int(release) < 24:
-                self.variant = "Server"
-            else:
-                self.variant = "Everything"
         self.bootopts = bootopts
 
     @property
@@ -290,11 +281,6 @@ class VirtInstallImage(object):
             rockydir = 'rocky-secondary'
             memsize = '4096'
 
-        variant = self.variant
-        # From F31 onwards, Workstation tree is not installable and we
-        # build Workstation images out of Everything
-        # We will always use the dvd1 ISO and the closest behavior is the Everything variant
-        variant = 'Everything'
         try:
             # loctmp is the Distribution tree installation source. Point at the good location
             #loctmp = "https://download.rockylinux.org/stg/rocky/{0}/BaseOS/{1}/os"
@@ -470,8 +456,6 @@ def get_virtinstall_images(imggrp, nextrel=None, releases=None):
     name = imggrp['name']
     # this is the second place we set a default for maxage - bit ugly
     maxage = int(imggrp.get('maxage', 14))
-    # ditto variant
-    variant = imggrp.get('variant')
     if not releases:
         releases = imggrp['releases']
     size = imggrp.get('size', 0)
@@ -486,7 +470,7 @@ def get_virtinstall_images(imggrp, nextrel=None, releases=None):
                     continue
                 key = "{0}-{1}".format(rel, arch)
                 # using a dict here avoids dupes
-                imgs[key] = VirtInstallImage(name, rel, arch, variant=variant, size=size,
+                imgs[key] = VirtInstallImage(name, rel, arch, size=size,
                                              imgver=imgver, maxage=maxage, bootopts=bootopts)
     return list(imgs.values())
 

--- a/createhdds.py
+++ b/createhdds.py
@@ -286,14 +286,9 @@ class VirtInstallImage(object):
         arch = self.arch
         rockydir = 'rocky/linux'
         memsize = '3072'
-        if arch == 'i686':
-            arch = 'i386'
         if arch in ['ppc64','ppc64le']:
             rockydir = 'rocky-secondary'
             memsize = '4096'
-        if arch == 'i386':
-            # i686 is in rocky-secondary (until it died)
-            rockydir = 'rocky-secondary'
 
         variant = self.variant
         # From F31 onwards, Workstation tree is not installable and we

--- a/createhdds.py
+++ b/createhdds.py
@@ -256,7 +256,7 @@ class VirtInstallImage(object):
         if shortid not in out:
             # this will just use the most recent rocky release number
             # virt-install / osinfo knows
-            shortid = 'rocky8-unknown'
+            shortid = 'rocky9.0'
 
         # destroy and delete the domain we use for all virt-installs
         conn = libvirt.open()

--- a/createhdds.py
+++ b/createhdds.py
@@ -256,7 +256,7 @@ class VirtInstallImage(object):
         if shortid not in out:
             # this will just use the most recent rocky release number
             # virt-install / osinfo knows
-            shortid = "rocky{0}".format(release).split('.')[0] + "-unknown"
+            shortid = "rocky{0}".format(self.release).split('.')[0] + "-unknown"
 
         # destroy and delete the domain we use for all virt-installs
         conn = libvirt.open()

--- a/createhdds.py
+++ b/createhdds.py
@@ -256,7 +256,7 @@ class VirtInstallImage(object):
         if shortid not in out:
             # this will just use the most recent rocky release number
             # virt-install / osinfo knows
-            shortid = "rocky{0}-unknown".format(self.release)
+            shortid = "rocky{0}".format(release).split('.')[0] + "-unknown"
 
         # destroy and delete the domain we use for all virt-installs
         conn = libvirt.open()

--- a/createhdds.py
+++ b/createhdds.py
@@ -256,7 +256,7 @@ class VirtInstallImage(object):
         if shortid not in out:
             # this will just use the most recent rocky release number
             # virt-install / osinfo knows
-            shortid = 'rocky9.0'
+            shortid = "rocky{0}-unknown".format(self.release)
 
         # destroy and delete the domain we use for all virt-installs
         conn = libvirt.open()

--- a/desktop.ks
+++ b/desktop.ks
@@ -1,6 +1,6 @@
 bootloader --location=mbr
 network --bootproto=dhcp
-url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
+url --url="https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/"
 lang en_US.UTF-8
 keyboard us
 timezone --utc America/New_York

--- a/desktopencrypt-aarch64.ks
+++ b/desktopencrypt-aarch64.ks
@@ -1,6 +1,6 @@
 bootloader --location=mbr --append="console=tty0 quiet"
 network --bootproto=dhcp
-url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
+url --url="https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/"
 lang en_US.UTF-8
 keyboard us
 timezone --utc America/New_York

--- a/desktopencrypt.ks
+++ b/desktopencrypt.ks
@@ -1,6 +1,6 @@
 bootloader --location=mbr
 network --bootproto=dhcp
-url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
+url --url="https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/"
 lang en_US.UTF-8
 keyboard us
 timezone --utc America/New_York

--- a/hdds.json
+++ b/hdds.json
@@ -125,7 +125,6 @@
         {
             "name" : "minimal",
             "releases" : {
-                "8" : ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "15"
@@ -133,7 +132,6 @@
         {
             "name" : "minimal-uefi",
             "releases" : {
-                "8" : ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "15",
@@ -142,7 +140,6 @@
         {
             "name" : "desktop",
             "releases" : {
-                "8": ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "20"
@@ -150,7 +147,6 @@
         {
             "name" : "desktopencrypt",
             "releases" : {
-                "8" : ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "20"
@@ -158,7 +154,6 @@
         {
             "name" : "server",
             "releases" : {
-                "8" : ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "9"
@@ -166,7 +161,6 @@
         {
             "name" : "support",
             "releases" : {
-                "8" : ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "15"

--- a/hdds.json
+++ b/hdds.json
@@ -145,8 +145,7 @@
                 "8": ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
-            "size" : "20",
-            "variant": "Workstation"
+            "size" : "20"
         },
         {
             "name" : "desktopencrypt",
@@ -154,8 +153,7 @@
                 "8" : ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
-            "size" : "20",
-            "variant": "Workstation"
+            "size" : "20"
         },
         {
             "name" : "server",
@@ -163,8 +161,7 @@
                 "8" : ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
-            "size" : "9",
-            "variant": "Server"
+            "size" : "9"
         },
         {
             "name" : "support",

--- a/hdds.json
+++ b/hdds.json
@@ -125,14 +125,16 @@
         {
             "name" : "minimal",
             "releases" : {
-                "8" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "15"
         },
         {
             "name" : "minimal-uefi",
             "releases" : {
-                "8" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "15",
             "bootopts": "uefi"
@@ -140,7 +142,8 @@
         {
             "name" : "desktop",
             "releases" : {
-                "8": ["x86_64", "aarch64"]
+                "8": ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "20",
             "variant": "Workstation"
@@ -148,7 +151,8 @@
         {
             "name" : "desktopencrypt",
             "releases" : {
-                "8" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "20",
             "variant": "Workstation"
@@ -156,7 +160,8 @@
         {
             "name" : "server",
             "releases" : {
-                "8" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "9",
             "variant": "Server"
@@ -164,7 +169,8 @@
         {
             "name" : "support",
             "releases" : {
-                "8" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "15"
         }

--- a/hdds.json
+++ b/hdds.json
@@ -125,16 +125,16 @@
         {
             "name" : "minimal",
             "releases" : {
-                "8" : ["x86_64", "aarch64"],
-                "9" : ["x86_64", "aarch64"]
+                "8.6" : ["x86_64", "aarch64"],
+                "9.0" : ["x86_64", "aarch64"]
             },
             "size" : "15"
         },
         {
             "name" : "minimal-uefi",
             "releases" : {
-                "8" : ["x86_64", "aarch64"],
-                "9" : ["x86_64", "aarch64"]
+                "8.6" : ["x86_64", "aarch64"],
+                "9.0" : ["x86_64", "aarch64"]
             },
             "size" : "15",
             "bootopts": "uefi"
@@ -142,32 +142,32 @@
         {
             "name" : "desktop",
             "releases" : {
-                "8": ["x86_64", "aarch64"],
-                "9" : ["x86_64", "aarch64"]
+                "8.6" : ["x86_64", "aarch64"],
+                "9.0" : ["x86_64", "aarch64"]
             },
             "size" : "20"
         },
         {
             "name" : "desktopencrypt",
             "releases" : {
-                "8" : ["x86_64", "aarch64"],
-                "9" : ["x86_64", "aarch64"]
+                "8.6" : ["x86_64", "aarch64"],
+                "9.0" : ["x86_64", "aarch64"]
             },
             "size" : "20"
         },
         {
             "name" : "server",
             "releases" : {
-                "8" : ["x86_64", "aarch64"],
-                "9" : ["x86_64", "aarch64"]
+                "8.6" : ["x86_64", "aarch64"],
+                "9.0" : ["x86_64", "aarch64"]
             },
             "size" : "9"
         },
         {
             "name" : "support",
             "releases" : {
-                "8" : ["x86_64", "aarch64"],
-                "9" : ["x86_64", "aarch64"]
+                "8.6" : ["x86_64", "aarch64"],
+                "9.0" : ["x86_64", "aarch64"]
             },
             "size" : "15"
         }

--- a/hdds.json
+++ b/hdds.json
@@ -125,14 +125,14 @@
         {
             "name" : "minimal",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"]
             },
             "size" : "15"
         },
         {
             "name" : "minimal-uefi",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"]
             },
             "size" : "15",
             "bootopts": "uefi"
@@ -140,7 +140,7 @@
         {
             "name" : "desktop",
             "releases" : {
-                "8.6": ["x86_64", "aarch64"]
+                "8": ["x86_64", "aarch64"]
             },
             "size" : "20",
             "variant": "Workstation"
@@ -148,7 +148,7 @@
         {
             "name" : "desktopencrypt",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"]
             },
             "size" : "20",
             "variant": "Workstation"
@@ -156,7 +156,7 @@
         {
             "name" : "server",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"]
             },
             "size" : "9",
             "variant": "Server"
@@ -164,7 +164,7 @@
         {
             "name" : "support",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"]
             },
             "size" : "15"
         }

--- a/hdds.json
+++ b/hdds.json
@@ -125,16 +125,16 @@
         {
             "name" : "minimal",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"],
-                "9.0" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "15"
         },
         {
             "name" : "minimal-uefi",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"],
-                "9.0" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "15",
             "bootopts": "uefi"
@@ -142,32 +142,32 @@
         {
             "name" : "desktop",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"],
-                "9.0" : ["x86_64", "aarch64"]
+                "8": ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "20"
         },
         {
             "name" : "desktopencrypt",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"],
-                "9.0" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "20"
         },
         {
             "name" : "server",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"],
-                "9.0" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "9"
         },
         {
             "name" : "support",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"],
-                "9.0" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "15"
         }

--- a/hdds.json
+++ b/hdds.json
@@ -125,6 +125,7 @@
         {
             "name" : "minimal",
             "releases" : {
+                "8" : ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "15"
@@ -132,6 +133,7 @@
         {
             "name" : "minimal-uefi",
             "releases" : {
+                "8" : ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "15",
@@ -140,6 +142,7 @@
         {
             "name" : "desktop",
             "releases" : {
+                "8": ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "20"
@@ -147,6 +150,7 @@
         {
             "name" : "desktopencrypt",
             "releases" : {
+                "8" : ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "20"
@@ -154,6 +158,7 @@
         {
             "name" : "server",
             "releases" : {
+                "8" : ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "9"
@@ -161,6 +166,7 @@
         {
             "name" : "support",
             "releases" : {
+                "8" : ["x86_64", "aarch64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "15"

--- a/minimal-uefi.ks
+++ b/minimal-uefi.ks
@@ -1,6 +1,6 @@
 bootloader --location=mbr
 network --bootproto=dhcp
-url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
+url --url="https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/"
 lang en_US.UTF-8
 keyboard us
 timezone --utc America/New_York

--- a/minimal.ks
+++ b/minimal.ks
@@ -1,6 +1,6 @@
 bootloader --location=mbr
 network --bootproto=dhcp
-url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
+url --url="https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/"
 lang en_US.UTF-8
 keyboard us
 timezone --utc America/New_York

--- a/server.ks
+++ b/server.ks
@@ -1,6 +1,6 @@
 bootloader --location=mbr
 network --bootproto=dhcp
-url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
+url --url="https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/"
 lang en_US.UTF-8
 keyboard us
 timezone --utc America/New_York

--- a/support.ks
+++ b/support.ks
@@ -1,6 +1,6 @@
 bootloader --location=mbr
 network --bootproto=dhcp
-url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
+url --url="https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/"
 #repo --name="epel" --baseurl="http://mirrors.kernel.org/fedora-epel/8/Everything/x86_64/"
 # use epel to keep scsi-target-utils instead of targetcli
 lang en_US.UTF-8

--- a/uploads/root-user-crypted-net.ks
+++ b/uploads/root-user-crypted-net.ks
@@ -1,6 +1,6 @@
 bootloader --location=mbr
 network --device=link --activate --bootproto=dhcp
-url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
+url --url="https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/"
 lang en_US.UTF-8
 keyboard us
 timezone --utc America/New_York


### PR DESCRIPTION
## Description

This PR builds on the #8 (and as branch was created off of 8.6_release in my fork, includes those changes) and should be merged **AFTER** #8 (this should cause the May commits to disappear).

This PR updates the kickstart files for `rocky/9` and modifies `createhdds.py` to use the newly available `rocky9.0` OS information from `libosinfo`.

## How was this tested

```bash
[rocky@openqa-dev fixed]$ /home/rocky/createhdds/createhdds.py -t -l info minimal

# ...wait for quite a while...

[rocky@openqa-dev fixed]$ ls -l disk_rocky9_minimal_x86_64.qcow2
-rw-r--r--. 1 rocky geekotest 16108814336 Jul 16 10:33 disk_rocky9_minimal_x86_64.qcow2

[rocky@openqa-dev fixed]$ qemu-img info disk_rocky9_minimal_x86_64.qcow2
image: disk_rocky9_minimal_x86_64.qcow2
file format: qcow2
virtual size: 15 GiB (16106127360 bytes)
disk size: 1.33 GiB
cluster_size: 65536
Format specific information:
    compat: 1.1
    compression type: zlib
    lazy refcounts: true
    refcount bits: 16
    corrupt: false
    extended l2: false
```

<img width="406" alt="rocky9-createhdds-minimal-01" src="https://user-images.githubusercontent.com/542846/179366815-78554d51-b5b5-4f30-9184-95b334728075.png">

<img width="406" alt="rocky9-createhdds-minimal-05" src="https://user-images.githubusercontent.com/542846/179366816-b60c6d9a-c150-49bc-9bb1-e259a0be8c43.png">

<img width="406" alt="rocky9-createhdds-minimal-07" src="https://user-images.githubusercontent.com/542846/179366821-8e35b911-8a01-4c20-b3fe-83fe70f9732f.png">

