### PR TITLE
9.0 release branch 

### DIFF
--- a/createhdds.py
+++ b/createhdds.py
@@ -256,7 +256,7 @@ class VirtInstallImage(object):
         if shortid not in out:
             # this will just use the most recent rocky release number
             # virt-install / osinfo knows
-            shortid = 'rocky8-unknown'
+            shortid = "rocky{0}".format(self.release).split('.')[0] + "-unknown"
 
         # destroy and delete the domain we use for all virt-installs
         conn = libvirt.open()

--- a/createhdds.py
+++ b/createhdds.py
@@ -197,8 +197,7 @@ class GuestfsImage(object):
 
 class VirtInstallImage(object):
     """Class representing an image created by virt-install. 'release'
-    is the release the image will be built for. 'variant' is the
-    variant whose install tree should be used. 'arch' is the arch.
+    is the release the image will be built for. 'arch' is the arch.
     'size' is the desired image size, in gigabytes. 'imgver' is
     the image 'version' - in practice it's simply a string that gets
     included in the image file name if specified. 'maxage' is the
@@ -207,7 +206,7 @@ class VirtInstallImage(object):
     rebuild it. 'bootopts' are used to pass boot options to the
     virtual image to provide better control of the VM.
     """
-    def __init__(self, name, release, arch, size, variant=None, imgver='', maxage=14, bootopts=None):
+    def __init__(self, name, release, arch, size, imgver='', maxage=14, bootopts=None):
         self.name = name
         self.size = size
         self.filename = "disk_rocky{0}_{1}".format(str(release), name)
@@ -215,16 +214,8 @@ class VirtInstallImage(object):
             self.filename = "{0}_{1}".format(self.filename, imgver)
         self.filename = "{0}_{1}.qcow2".format(self.filename, arch)
         self.release = release
-        self.variant = variant
         self.arch = arch
         self.maxage = maxage
-        if variant:
-            self.variant = variant
-        else:
-            if str(release).isdigit() and int(release) < 24:
-                self.variant = "Server"
-            else:
-                self.variant = "Everything"
         self.bootopts = bootopts
 
     @property
@@ -286,20 +277,10 @@ class VirtInstallImage(object):
         arch = self.arch
         rockydir = 'rocky/linux'
         memsize = '3072'
-        if arch == 'i686':
-            arch = 'i386'
         if arch in ['ppc64','ppc64le']:
             rockydir = 'rocky-secondary'
             memsize = '4096'
-        if arch == 'i386':
-            # i686 is in rocky-secondary (until it died)
-            rockydir = 'rocky-secondary'
 
-        variant = self.variant
-        # From F31 onwards, Workstation tree is not installable and we
-        # build Workstation images out of Everything
-        # We will always use the dvd1 ISO and the closest behavior is the Everything variant
-        variant = 'Everything'
         try:
             # loctmp is the Distribution tree installation source. Point at the good location
             #loctmp = "https://download.rockylinux.org/stg/rocky/{0}/BaseOS/{1}/os"
@@ -475,8 +456,6 @@ def get_virtinstall_images(imggrp, nextrel=None, releases=None):
     name = imggrp['name']
     # this is the second place we set a default for maxage - bit ugly
     maxage = int(imggrp.get('maxage', 14))
-    # ditto variant
-    variant = imggrp.get('variant')
     if not releases:
         releases = imggrp['releases']
     size = imggrp.get('size', 0)
@@ -491,7 +470,7 @@ def get_virtinstall_images(imggrp, nextrel=None, releases=None):
                     continue
                 key = "{0}-{1}".format(rel, arch)
                 # using a dict here avoids dupes
-                imgs[key] = VirtInstallImage(name, rel, arch, variant=variant, size=size,
+                imgs[key] = VirtInstallImage(name, rel, arch, size=size,
                                              imgver=imgver, maxage=maxage, bootopts=bootopts)
     return list(imgs.values())
 

--- a/createhdds.py
+++ b/createhdds.py
@@ -302,6 +302,7 @@ class VirtInstallImage(object):
         variant = 'Everything'
         try:
             # loctmp is the Distribution tree installation source. Point at the good location
+            #loctmp = "https://download.rockylinux.org/stg/rocky/{0}/BaseOS/{1}/os"
             loctmp = "https://download.rockylinux.org/pub/rocky/{0}/BaseOS/{1}/os"
             ksfile = self.kickstart_file
             xargs = "inst.ks=file:/{0}".format(ksfile)

--- a/createhdds.py
+++ b/createhdds.py
@@ -265,7 +265,7 @@ class VirtInstallImage(object):
         if shortid not in out:
             # this will just use the most recent rocky release number
             # virt-install / osinfo knows
-            shortid = 'rocky-unknown'
+            shortid = 'rocky8-unknown'
 
         # destroy and delete the domain we use for all virt-installs
         conn = libvirt.open()

--- a/desktop.ks
+++ b/desktop.ks
@@ -1,6 +1,6 @@
 bootloader --location=mbr
 network --bootproto=dhcp
-url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
+url --url="https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/"
 lang en_US.UTF-8
 keyboard us
 timezone --utc America/New_York

--- a/desktopencrypt-aarch64.ks
+++ b/desktopencrypt-aarch64.ks
@@ -1,6 +1,6 @@
 bootloader --location=mbr --append="console=tty0 quiet"
 network --bootproto=dhcp
-url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
+url --url="https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/"
 lang en_US.UTF-8
 keyboard us
 timezone --utc America/New_York

--- a/desktopencrypt.ks
+++ b/desktopencrypt.ks
@@ -1,6 +1,6 @@
 bootloader --location=mbr
 network --bootproto=dhcp
-url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
+url --url="https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/"
 lang en_US.UTF-8
 keyboard us
 timezone --utc America/New_York

--- a/hdds.json
+++ b/hdds.json
@@ -2,19 +2,19 @@
     "guestfs" : [
         {
             "name" : "full",
-            "size" : "10G",
+            "size" : "25G",
             "labels" : ["mbr", "gpt"],
             "parts" : [
                 {
                     "filesystem" : "ext4",
                     "type" : "p",
                     "start" : "4096",
-                    "end" : "10485760"
+                    "end" : "26214400"
                 },
                 {
                     "filesystem" : "ext4",
                     "type" : "p",
-                    "start" : "10485761",
+                    "start" : "26214401",
                     "end" : "-4097"
                 }
             ],

--- a/hdds.json
+++ b/hdds.json
@@ -127,14 +127,14 @@
             "releases" : {
                 "8.6" : ["x86_64", "aarch64"]
             },
-            "size" : "10"
+            "size" : "15"
         },
         {
             "name" : "minimal-uefi",
             "releases" : {
                 "8.6" : ["x86_64", "aarch64"]
             },
-            "size" : "10",
+            "size" : "15",
             "bootopts": "uefi"
         },
         {
@@ -158,7 +158,7 @@
             "releases" : {
                 "8.6" : ["x86_64", "aarch64"]
             },
-            "size" : "7",
+            "size" : "9",
             "variant": "Server"
         },
         {
@@ -166,7 +166,7 @@
             "releases" : {
                 "8.6" : ["x86_64", "aarch64"]
             },
-            "size" : "11"
+            "size" : "15"
         }
     ],
     "renames" : []

--- a/hdds.json
+++ b/hdds.json
@@ -125,14 +125,14 @@
         {
             "name" : "minimal",
             "releases" : {
-                "8.5" : ["x86_64", "aarch64"]
+                "8.6" : ["x86_64", "aarch64"]
             },
             "size" : "10"
         },
         {
             "name" : "minimal-uefi",
             "releases" : {
-                "8.5" : ["x86_64", "aarch64"]
+                "8.6" : ["x86_64", "aarch64"]
             },
             "size" : "10",
             "bootopts": "uefi"
@@ -140,7 +140,7 @@
         {
             "name" : "desktop",
             "releases" : {
-                "8.5": ["x86_64", "aarch64"]
+                "8.6": ["x86_64", "aarch64"]
             },
             "size" : "20",
             "variant": "Workstation"
@@ -148,7 +148,7 @@
         {
             "name" : "desktopencrypt",
             "releases" : {
-                "8.5" : ["x86_64", "aarch64"]
+                "8.6" : ["x86_64", "aarch64"]
             },
             "size" : "20",
             "variant": "Workstation"
@@ -156,7 +156,7 @@
         {
             "name" : "server",
             "releases" : {
-                "8.5" : ["x86_64", "aarch64"]
+                "8.6" : ["x86_64", "aarch64"]
             },
             "size" : "7",
             "variant": "Server"
@@ -164,7 +164,7 @@
         {
             "name" : "support",
             "releases" : {
-                "8.5" : ["x86_64", "aarch64"]
+                "8.6" : ["x86_64", "aarch64"]
             },
             "size" : "11"
         }

--- a/hdds.json
+++ b/hdds.json
@@ -125,14 +125,16 @@
         {
             "name" : "minimal",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "15"
         },
         {
             "name" : "minimal-uefi",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "15",
             "bootopts": "uefi"
@@ -140,31 +142,32 @@
         {
             "name" : "desktop",
             "releases" : {
-                "8.6": ["x86_64", "aarch64"]
+                "8": ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
-            "size" : "20",
-            "variant": "Workstation"
+            "size" : "20"
         },
         {
             "name" : "desktopencrypt",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
-            "size" : "20",
-            "variant": "Workstation"
+            "size" : "20"
         },
         {
             "name" : "server",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
-            "size" : "9",
-            "variant": "Server"
+            "size" : "9"
         },
         {
             "name" : "support",
             "releases" : {
-                "8.6" : ["x86_64", "aarch64"]
+                "8" : ["x86_64", "aarch64"],
+                "9" : ["x86_64", "aarch64"]
             },
             "size" : "15"
         }

--- a/minimal-uefi.ks
+++ b/minimal-uefi.ks
@@ -1,6 +1,6 @@
 bootloader --location=mbr
 network --bootproto=dhcp
-url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
+url --url="https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/"
 lang en_US.UTF-8
 keyboard us
 timezone --utc America/New_York

--- a/minimal.ks
+++ b/minimal.ks
@@ -1,6 +1,6 @@
 bootloader --location=mbr
 network --bootproto=dhcp
-url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
+url --url="https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/"
 lang en_US.UTF-8
 keyboard us
 timezone --utc America/New_York

--- a/server.ks
+++ b/server.ks
@@ -1,6 +1,6 @@
 bootloader --location=mbr
 network --bootproto=dhcp
-url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
+url --url="https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/"
 lang en_US.UTF-8
 keyboard us
 timezone --utc America/New_York

--- a/support.ks
+++ b/support.ks
@@ -1,6 +1,6 @@
 bootloader --location=mbr
 network --bootproto=dhcp
-url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
+url --url="https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/"
 #repo --name="epel" --baseurl="http://mirrors.kernel.org/fedora-epel/8/Everything/x86_64/"
 # use epel to keep scsi-target-utils instead of targetcli
 lang en_US.UTF-8

--- a/uploads/root-user-crypted-net.ks
+++ b/uploads/root-user-crypted-net.ks
@@ -1,6 +1,6 @@
 bootloader --location=mbr
 network --device=link --activate --bootproto=dhcp
-url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/"
+url --url="https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/"
 lang en_US.UTF-8
 keyboard us
 timezone --utc America/New_York


### PR DESCRIPTION
The 9.0_release branch was created from the 8.6_release branch and has been kept compatible with both releases by previous code authors.    9.0_release branch now generates a full set of images for both releases as shown:-

alan@107 ~/g/createhdds (9.0_release)> ls -alh
total 37G
drwxr-xr-x. 4 alan alan 4.0K Aug 18 12:22 ./
drwxr-xr-x. 6 alan alan 4.0K Aug  6 14:42 ../
-rwxr-xr-x. 1 alan alan  35K Aug 18 06:54 createhdds.py*
-rw-r--r--. 1 alan alan  466 Aug 18 06:54 desktopencrypt-aarch64.ks
-rw-r--r--. 1 alan alan  436 Aug 18 06:54 desktopencrypt.ks
-rw-r--r--. 1 alan alan  450 Aug 18 06:54 desktop.ks
-rw-r--r--. 1 alan alan  10G Aug 18 07:08 disk_freespace_gpt.img
-rw-r--r--. 1 alan alan  10G Aug 18 07:08 disk_freespace_mbr.img
-rw-r--r--. 1 alan alan  25G Aug 18 07:07 disk_full_gpt.img
-rw-r--r--. 1 alan alan  25G Aug 18 07:07 disk_full_mbr.img
-rw-r--r--. 1 alan alan 100M Aug 18 07:08 disk_ks.img
-rw-r--r--. 1 alan alan  21G Aug 18 08:44 disk_rocky8_desktopencrypt_x86_64.qcow2
-rw-r--r--. 1 alan alan  21G Aug 18 08:03 disk_rocky8_desktop_x86_64.qcow2
-rw-r--r--. 1 alan alan  16G Aug 18 07:29 disk_rocky8_minimal-uefi_x86_64.qcow2
-rw-r--r--. 1 alan alan  11G Aug  6 08:15 disk_rocky8_minimal_x86_64.qcow2
-rw-r--r--. 1 alan alan 9.1G Aug 18 10:24 disk_rocky8_server_x86_64.qcow2
-rw-r--r--. 1 alan alan  16G Aug 18 12:10 disk_rocky8_support_x86_64.qcow2
-rw-r--r--. 1 alan alan  21G Aug 18 10:07 disk_rocky9_desktopencrypt_x86_64.qcow2
-rw-r--r--. 1 alan alan  21G Aug 18 11:57 disk_rocky9_desktop_x86_64.qcow2
-rw-r--r--. 1 alan alan  16G Aug 18 07:41 disk_rocky9_minimal-uefi_x86_64.qcow2
-rw-r--r--. 1 alan alan  16G Aug 18 07:19 disk_rocky9_minimal_x86_64.qcow2
-rw-r--r--. 1 alan alan 9.1G Aug 18 10:40 disk_rocky9_server_x86_64.qcow2
-rw-r--r--. 1 alan alan  16G Aug 18 12:22 disk_rocky9_support_x86_64.qcow2
-rw-r--r--. 1 alan alan  10G Aug 18 07:08 disk_shrink_ext4.img
-rw-r--r--. 1 alan alan  10G Aug 18 07:08 disk_shrink_ntfs.img
-rw-r--r--. 1 alan alan 100M Aug 18 07:08 disk_updates_img.img
drwxr-xr-x. 8 alan alan 4.0K Aug 18 06:58 .git/
-rw-r--r--. 1 alan alan 4.7K Aug 18 06:54 hdds.json
-rw-r--r--. 1 alan alan  262 Aug 18 06:54 minimal.ks
-rw-r--r--. 1 alan alan  314 Aug 18 06:54 minimal-uefi.ks
-rw-r--r--. 1 alan alan  20K Aug  6 07:38 README.md
-rw-r--r--. 1 alan alan  360 Aug 18 06:54 server.ks
-rw-r--r--. 1 alan alan  439 Aug 18 06:54 support.ks
drwxr-xr-x. 2 alan alan   99 Aug 18 06:54 uploads/
alan@107 ~/g/createhdds (9.0_release)> 

As it stands, anyone wishing to generate these images needs to use 9.0_release branch and not the very out of date default.  It is therefore proposed to merge both release branches to rocky so that the combined image generation can be done form there.
There are no code changes in this PR it is proposed as a tidy up.
