### PR TITLE
Add beta support to createhdds.py

### DIFF
--- a/createhdds.py
+++ b/createhdds.py
@@ -607,7 +607,10 @@ def cli_all(args, hdds):
     missing.extend(outdated)
     for (num, img) in enumerate(missing, 1):
         logger.info("Creating image %s...[%s/%s]", img.filename, str(num), str(len(missing)))
-        img.create(args.baseurl, args.textinst)
+        if img.filename.endswith(".img"):
+          img.create(args.textinst)
+        else:
+          img.create(args.baseurl, args.textinst)
 
 def cli_check(args, hdds):
     """Function for the CLI 'check' subcommand. Basically just calls
@@ -685,7 +688,10 @@ def cli_image(args, *_):
 
     for (num, img) in enumerate(imgs, 1):
         logger.info("Creating image %s...[%s/%s]", img.filename, str(num), str(len(imgs)))
-        img.create(args.baseurl, args.textinst)
+        if imgtype == 'guestfs':
+          img.create(args.textinst)
+        else:
+          img.create(args.baseurl, args.textinst)
 
 def parse_args(hdds):
     """Parse arguments with argparse."""

--- a/desktop-8.7-Beta.ks
+++ b/desktop-8.7-Beta.ks
@@ -1,0 +1,21 @@
+bootloader --location=mbr
+network --bootproto=dhcp
+url --url="https://download.rockylinux.org/stg/rocky/8.7-Beta/BaseOS/x86_64/os/"
+lang en_US.UTF-8
+keyboard us
+timezone --utc America/New_York
+clearpart --all
+autopart
+rootpw --plaintext weakpassword
+user --name=test --password=weakpassword --plaintext
+firstboot --enable
+poweroff
+
+%packages
+@^workstation-product-environment
+-selinux-policy-minimum
+%end
+
+%post
+touch $INSTALL_ROOT/home/home_preserved
+%end

--- a/desktopencrypt-8.7-Beta.ks
+++ b/desktopencrypt-8.7-Beta.ks
@@ -1,0 +1,17 @@
+bootloader --location=mbr
+network --bootproto=dhcp
+url --url="https://download.rockylinux.org/stg/rocky/8.7-Beta/BaseOS/x86_64/os/"
+lang en_US.UTF-8
+keyboard us
+timezone --utc America/New_York
+clearpart --all
+autopart --encrypted --passphrase=weakpassword
+rootpw --plaintext weakpassword
+user --name=test --password=weakpassword --plaintext
+firstboot --enable
+poweroff
+
+%packages
+@^workstation-product-environment
+-selinux-policy-minimum
+%end

--- a/hdds.json
+++ b/hdds.json
@@ -155,6 +155,7 @@
             "name" : "minimal",
             "releases" : {
                 "8" : ["x86_64", "aarch64"],
+                "8.7-Beta" : ["x86_64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "15"
@@ -163,6 +164,7 @@
             "name" : "minimal-uefi",
             "releases" : {
                 "8" : ["x86_64", "aarch64"],
+                "8.7-Beta" : ["x86_64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "15",
@@ -172,6 +174,7 @@
             "name" : "desktop",
             "releases" : {
                 "8": ["x86_64", "aarch64"],
+                "8.7-Beta" : ["x86_64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "20"
@@ -180,6 +183,7 @@
             "name" : "desktopencrypt",
             "releases" : {
                 "8" : ["x86_64", "aarch64"],
+                "8.7-Beta" : ["x86_64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "20"
@@ -188,6 +192,7 @@
             "name" : "server",
             "releases" : {
                 "8" : ["x86_64", "aarch64"],
+                "8.7-Beta" : ["x86_64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "9"
@@ -196,6 +201,7 @@
             "name" : "support",
             "releases" : {
                 "8" : ["x86_64", "aarch64"],
+                "8.7-Beta" : ["x86_64"],
                 "9" : ["x86_64", "aarch64"]
             },
             "size" : "30"

--- a/minimal-8.7-Beta.ks
+++ b/minimal-8.7-Beta.ks
@@ -1,0 +1,14 @@
+bootloader --location=mbr
+network --bootproto=dhcp
+url --url="https://download.rockylinux.org/stg/rocky/8.7-Beta/BaseOS/x86_64/os/"
+lang en_US.UTF-8
+keyboard us
+timezone --utc America/New_York
+clearpart --all
+autopart
+rootpw weakpassword
+poweroff
+
+%packages
+@core
+%end

--- a/minimal-uefi-8.7-Beta.ks
+++ b/minimal-uefi-8.7-Beta.ks
@@ -1,0 +1,18 @@
+bootloader --location=mbr
+network --bootproto=dhcp
+url --url="https://download.rockylinux.org/stg/rocky/8.7-Beta/BaseOS/x86_64/os/"
+lang en_US.UTF-8
+keyboard us
+timezone --utc America/New_York
+clearpart --all
+autopart
+rootpw weakpassword
+poweroff
+
+%packages
+@core
+%end
+
+%post
+touch $INSTALL_ROOT/home/home_preserved
+%end

--- a/server-8.7-Beta.ks
+++ b/server-8.7-Beta.ks
@@ -1,0 +1,16 @@
+bootloader --location=mbr
+network --bootproto=dhcp
+url --url="https://download.rockylinux.org/stg/rocky/8.7-Beta/BaseOS/x86_64/os/"
+lang en_US.UTF-8
+keyboard us
+timezone --utc America/New_York
+clearpart --all
+autopart
+rootpw weakpassword
+user --name=test --password=weakpassword --plaintext
+poweroff
+
+%packages
+@^server-product-environment
+plymouth-system-theme
+%end

--- a/support-8.7-Beta.ks
+++ b/support-8.7-Beta.ks
@@ -1,0 +1,19 @@
+bootloader --location=mbr
+network --bootproto=dhcp
+url --url="https://download.rockylinux.org/stg/rocky/8.7-Beta/BaseOS/x86_64/os/"
+#repo --name="epel" --baseurl="http://mirrors.kernel.org/fedora-epel/8/Everything/x86_64/"
+# use epel to keep scsi-target-utils instead of targetcli
+lang en_US.UTF-8
+keyboard us
+timezone --utc America/New_York
+clearpart --all
+autopart
+rootpw weakpassword
+poweroff
+
+%packages
+@core
+targetcli
+nfs-utils
+dnsmasq
+%end


### PR DESCRIPTION
This PR will add support for building Beta qcow2 images with virt-install via `createhdds.py`.

It accomplishes this primarly via the addition of an optional parameter `-b` or `--baseurl`...

```
$ /vagrant/createhdds/createhdds.py --help
usage: createhdds.py [-h] [-l {debug,info,warning,error,critical}] [-t]
                     [-b {pub,stg}]
                     {all,check,full,freespace,ks-8,ks-9,updates_img,shrink,minimal,minimal-uefi,desktop,desktopencrypt,server,support}
                     ...

Tool for creating hard disk images for Rocky Linux openQA.

positional arguments:
  {all,check,full,freespace,ks-8,ks-9,updates_img,shrink,minimal,minimal-uefi,desktop,desktopencrypt,server,support}

optional arguments:
  -h, --help            show this help message and exit
  -l {debug,info,warning,error,critical}, --loglevel {debug,info,warning,error,critical}
                        The level of log messages to show
  -t, --textinst        For any virt-install images, run the install in text
                        mode and show details on stdout
  -b {pub,stg}, --baseurl {pub,stg}
                        For any virt-install images, support alt baseurl for
                        initrd and vmlinuz.
```

...with additional support specifically for 8.7-Beta by the addition of kickstart files and configuration in `hdds.json`.

Future Beta versions will require additional changes to `hdds.json` and provision of additional kickstart files until/unless `createhdds.py` is modified to generate release specific kickstarts from templates.

This has been tested for x86_64 with all but the `minimal-uefi` image which I cannot build on my nested-virt system.

### Example command...
 ```
$ /vagrant/createhdds/createhdds.py -b stg -l info -t server -r 8.7-Beta
INFO:createhdds:Creating image disk_rocky8.7-Beta_server_x86_64.qcow2...[1/1]
libvirt: QEMU Driver error : Domain not found: no domain with matching name 'createhdds'
INFO:createhdds:Install starting...

Starting install...
Retrieving file vmlinuz...                                |  10 MB  00:00:00
Retrieving file initrd.img...                             |  82 MB  00:00:02
Allocating 'disk_rocky8.7-Beta_server_x86_64.qcow2.tmp'   | 9.0 GB  00:00:00
Running text console command: virsh --connect qemu:///session console createhdds
Connected to domain 'createhdds'
Escape character is ^] (Ctrl + ])
...
Domain has shutdown. Continuing.
Domain creation completed.
You can restart your domain by running:
  virsh --connect qemu:///session start createhdds

$ ls -lh disk_rocky8.7-Beta_server_x86_64.qcow2
-rw-r--r--. 1 vagrant vagrant 9.1G Oct  9 22:23 disk_rocky8.7-Beta_server_x86_64.qcow2

$ qemu-img check disk_rocky8.7-Beta_server_x86_64.qcow2
No errors were found on the image.
147456/147456 = 100.00% allocated, 0.00% fragmented, 0.00% compressed clusters
Image end offset: 9665380352
```