### PR TITLE
Provide alternative function to detect cpu arch

### DIFF
--- a/createhdds.py
+++ b/createhdds.py
@@ -42,6 +42,7 @@ from six.moves.urllib.request import urlopen
 # directory.
 SCRIPTDIR = os.path.abspath(os.path.dirname(sys.argv[0]))
 CPUARCH = platform.processor()
+if CPUARCH == '' : CPUARCH = platform.machine()
 logger = logging.getLogger('createhdds')
 
 def handle_size(size):


### PR DESCRIPTION
On x86_64 using fedora38, the python3 function ```platform.processor()``` no longer returns the cpu arch as before.
This MR provides fallback to an alternative function ```platform.machine()``` which returns the correct arch.

Tested:
Navigate to createhdds directory, then:
```
./createhdds.py -t support
```
Result:
Support server qcow2 files built successfully.

I do not have any ```aarch64``` hardware so am unable to check that this still works correctly.
Would someone else please test.
