### PR TITLE
fix ipadomain for freeipa and freeipaclient kickstarts

### DIFF
--- a/uploads/freeipa.ks
+++ b/uploads/freeipa.ks
@@ -1,6 +1,6 @@
 cdrom
 bootloader --location=mbr
-network --device=link --activate --bootproto=static --ip=172.16.2.100 --netmask=255.255.255.0 --gateway=172.16.2.2 --hostname=ipa001.test.openqa.fedoraproject.org
+network --device=link --activate --bootproto=static --ip=172.16.2.100 --netmask=255.255.255.0 --gateway=172.16.2.2 --hostname=ipa001.test.openqa.rockylinux.org
 lang en_US.UTF-8
 keyboard us
 timezone --utc America/New_York

--- a/uploads/freeipaclient.ks
+++ b/uploads/freeipaclient.ks
@@ -1,6 +1,6 @@
 cdrom
 bootloader --location=mbr
-network --device=link --activate --bootproto=static --ip=172.16.2.101 --netmask=255.255.255.0 --gateway=172.16.2.2 --hostname=client001.test.openqa.fedoraproject.org --nameserver=172.16.2.100
+network --device=link --activate --bootproto=static --ip=172.16.2.101 --netmask=255.255.255.0 --gateway=172.16.2.2 --hostname=client001.test.openqa.rockylinux.org --nameserver=172.16.2.100
 lang en_US.UTF-8
 keyboard us
 timezone --utc America/New_York
@@ -11,4 +11,4 @@ autopart
 %end
 rootpw anaconda
 reboot
-realm join --one-time-password=monkeys ipa001.test.openqa.fedoraproject.org
+realm join --one-time-password=monkeys ipa001.test.openqa.rockylinux.org


### PR DESCRIPTION
This PR updates freeipa server and client kickstart files to use the proper IPA domain when configuring the host and, in the client case, when attempting to join the client to the FreeIPA realm.

After this PR is merged the support server and server disks should be rebuilt with createhdds for both Rocky Linux 8 and 9 and redeployed on the production openQA system.