### PR TITLE
fix: Enable kdump using `%addon com_redhat_kdump`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Optional keys are:
 * `filesystem` - if set, this partition will *always* have this filesystem. If not set, the filesystem will be determined according to the image group's `filesystems` value (see below).
 * `label` - if set, this partition will have this label
 * `gpt-type` - if set, the partition will be of the type defined by the partition GUID.
+
 #### `writes`
 
 This key is **optional**. Its value is a list of dicts. Each dict represents a single file that should be created on one of the partitions in the image. There are exactly three required keys for the dict:
@@ -99,11 +100,11 @@ Whew! That was a lot of explanation, but it's not really a super-complicated con
 
 #### `releases`
 
-This key is **required**. It defines the releases and arches for which images are expected; thus it determines the number of images that will be expected for this group. The value is a dict. Each key in the dict represents a release; the value for each key is a list of the arches for which images should be built for that release. The keys should be integer digit strings. **Positive** values indicate absolute release numbers. **Negative** values are relative to whatever is the pending release at the time the images are created. So a release number `-1` means 'the release one before the pending release at the time the images are built'. So if the next Rocky Linux release will be Fedora 24 at the time the images are created, and one of the dict keys is `-1`, an image will be expected for Fedora 23.
+This key is **required**. It defines the releases and arches for which images are expected; thus it determines the number of images that will be expected for this group. The value is a dict. Each key in the dict represents a release; the value for each key is a list of the arches for which images should be built for that release. The keys should be **Positive** integer digit strings. A release number of `9` means Rocky Linux major version 9. The Rocky Linux minor version used to create the installed machine is controlled by the symlinks on the download server.
 
-The filename for a virt-install type image always includes the release number and arch it's built for - `disk_f(release)_(name)_(arch).img`.
+The filename for a virt-install type image always includes the release number and arch it's built for - `disk_rocky(release)_(name)_(arch).img`.
 
-Let's look at an example! Say the `name` is `minimal` and the `releases` dict is `{ "-1" : ["i686", "x86_64"], "-2" : ["x86_64"] }`. Three images will be expected, and the expected releases will be relevant to the pending release. Say the pending release is Fedora 24, the expected images will be `disk_f23_minimal_i686.img` (Fedora 23 for i686), `disk_f23_minimal_x86_64.img` (Fedora 23 for x86_64), and `disk_f22_minimal_x86_64.img` (Fedora 22 for x86_64). When time moves on and the next pending release is F25, images will be expected for Fedora 23 and Fedora 24, and the Fedora 22 images will be considered obsolete and deleted by cleanup modes of `createhdds`.
+Let's look at an example! Say the `name` is `minimal` and the `releases` dict is `{ "9" : ["x86_64"], "9" : ["x86_64"] }`. Two images will be expected with names `disk_rocky8_minimal_x86_64.img` (Rocky Linux 8 for x86_64) and `disk_rocky9_minimal_x86_64.img` (Rocky Linux 9 for x86_64). 
 
 As with the `guestfs` case, the single image group subcommand will have parameters to limit creation. So in our example, the `minimal` subcommand will have `--release` and `--arch` parameters, each allowing just a single value. For coding simplicity, passing `--arch` alone is ignored (this may be fixed later) and will just result in the 'expected' images being created. If `--release` is passed, only a single image will be created, for whatever release is specified; by default it will be the x86_64 image, you may pass `--arch (arch)` to build another arch instead.
 

--- a/desktop-8.ks
+++ b/desktop-8.ks
@@ -17,6 +17,9 @@ text
 -selinux-policy-minimum
 %end
 
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end
+
 %post
 touch $INSTALL_ROOT/home/home_preserved
 %end

--- a/desktop.ks
+++ b/desktop.ks
@@ -17,6 +17,9 @@ text
 -selinux-policy-minimum
 %end
 
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end
+
 %post
 touch $INSTALL_ROOT/home/home_preserved
 %end

--- a/desktopencrypt-8.ks
+++ b/desktopencrypt-8.ks
@@ -16,3 +16,6 @@ text
 @^workstation-product-environment
 -selinux-policy-minimum
 %end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end

--- a/desktopencrypt-aarch64-8.ks
+++ b/desktopencrypt-aarch64-8.ks
@@ -16,3 +16,6 @@ text
 @^workstation-product-environment
 -selinux-policy-minimum
 %end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end

--- a/desktopencrypt-aarch64.ks
+++ b/desktopencrypt-aarch64.ks
@@ -16,3 +16,6 @@ text
 @^workstation-product-environment
 -selinux-policy-minimum
 %end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end

--- a/desktopencrypt.ks
+++ b/desktopencrypt.ks
@@ -16,3 +16,6 @@ text
 @^workstation-product-environment
 -selinux-policy-minimum
 %end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end

--- a/minimal-8.ks
+++ b/minimal-8.ks
@@ -14,6 +14,9 @@ text
 @core
 %end
 
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end
+
 %post
 touch $INSTALL_ROOT/home/home_preserved
 %end

--- a/minimal-bios-8.ks
+++ b/minimal-bios-8.ks
@@ -14,6 +14,9 @@ text
 @core
 %end
 
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end
+
 %post
 touch $INSTALL_ROOT/home/home_preserved
 %end

--- a/minimal-bios.ks
+++ b/minimal-bios.ks
@@ -13,3 +13,6 @@ text
 %packages
 @core
 %end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end

--- a/minimal-uefi.ks
+++ b/minimal-uefi.ks
@@ -14,6 +14,9 @@ text
 @core
 %end
 
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end
+
 %post
 touch $INSTALL_ROOT/home/home_preserved
 %end

--- a/minimal.ks
+++ b/minimal.ks
@@ -14,6 +14,9 @@ text
 @core
 %end
 
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end
+
 %post
 touch $INSTALL_ROOT/home/home_preserved
 %end

--- a/server-8.ks
+++ b/server-8.ks
@@ -15,3 +15,6 @@ text
 @^server-product-environment
 plymouth-system-theme
 %end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end

--- a/server.ks
+++ b/server.ks
@@ -15,3 +15,6 @@ text
 @^server-product-environment
 plymouth-system-theme
 %end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end

--- a/support-8.ks
+++ b/support-8.ks
@@ -18,3 +18,6 @@ targetcli
 nfs-utils
 dnsmasq
 %end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end

--- a/support.ks
+++ b/support.ks
@@ -18,3 +18,6 @@ targetcli
 nfs-utils
 dnsmasq
 %end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end

--- a/uploads/freeipa.ks
+++ b/uploads/freeipa.ks
@@ -14,3 +14,6 @@ createrepo_c
 %end
 rootpw anaconda
 reboot
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end

--- a/uploads/freeipaclient.ks
+++ b/uploads/freeipaclient.ks
@@ -12,3 +12,6 @@ autopart
 rootpw anaconda
 reboot
 realm join --one-time-password=monkeys ipa001.test.openqa.rockylinux.org
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end

--- a/uploads/root-user-crypted-net-8.ks
+++ b/uploads/root-user-crypted-net-8.ks
@@ -15,3 +15,6 @@ reboot
 %packages
 @core
 %end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end

--- a/uploads/root-user-crypted-net-9.ks
+++ b/uploads/root-user-crypted-net-9.ks
@@ -15,3 +15,6 @@ reboot
 %packages
 @core
 %end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end


### PR DESCRIPTION
Two mechanisms exist to correctly configure a host to support kdump on first boot:

- The kernel command line option, `crashkernel` can be correctly configured, or
- the `com_redhat_kdump` Anaconda addon can be used.

While the use of `crashkernel=auto` is supported for Rocky Linux 8 that option was deprecated upstream for 9. In Rocky Linux 9 using `crashkernel=auto` results in a first boot failure of the systemd `kdump.service` which is easily resolved in an installed system but triggers failures in multiple openQA tests that require no failed services on first boot.

In Rocky Linux 9 either a completely configured `crashkernel` option (eg. `crashkernel=1G-4G:192M,4G-64G:256M,64G-:512M`...) must be _fully_ specified or the Anaconda addon `com_redhat_kdump` should be used  to complete all the required steps inside the installer environment to both configure and enable the `kdump.service`.

This merge request adopts the `com_redhat_kdump` solution and provides a mechanism separate from the fully configured `crashkernel` mainly to verify the `%addon com_redhat_kdump` option works correctly in Rocky Linux.

Starting with Rocky LInux 9 images built outside `createhdds` are built with [kiwi-ng](https://osinside.github.io/kiwi/) which requires the configuration of `crashkernel` and doesn't support the use of `%addon com_redhat_kdump` so continuing to build these images using the `%addon com_redhat_kdump` mechanism is useful to continue to verify upstream compatibility.

In addition, this PR updates the README.md file to remove some references to the upstream `relative release` concept as that is not supported by Rocky Linux major.minor release nomenclature.